### PR TITLE
Significant rework of zerodep implementation

### DIFF
--- a/akka/src/main/java/com/lightbend/microprofile/reactive/streams/akka/AkkaEngine.java
+++ b/akka/src/main/java/com/lightbend/microprofile/reactive/streams/akka/AkkaEngine.java
@@ -4,6 +4,7 @@
 
 package com.lightbend.microprofile.reactive.streams.akka;
 
+import akka.Done;
 import akka.NotUsed;
 import akka.stream.Attributes;
 import akka.stream.Materializer;
@@ -256,6 +257,9 @@ public class AkkaEngine implements ReactiveStreamsEngine {
       Predicate<Object> predicate = (Predicate) stage.getPredicate();
       return flow.dropWhile(predicate::test);
     });
+    addFlowStage(Stage.OnComplete.class, (flow, stage) -> flow.via(TerminationPeeker.onComplete(stage.getAction())));
+    addFlowStage(Stage.OnError.class, (flow, stage) -> flow.via(TerminationPeeker.onError(stage.getConsumer())));
+    addFlowStage(Stage.OnTerminate.class, (flow, stage) -> flow.via(TerminationPeeker.onTerminate(stage.getAction())));
 
     // Sinks
     addSinkStage(Stage.FindFirst.class, stage -> Sink.headOption());

--- a/akka/src/main/java/com/lightbend/microprofile/reactive/streams/akka/TerminationPeeker.java
+++ b/akka/src/main/java/com/lightbend/microprofile/reactive/streams/akka/TerminationPeeker.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.microprofile.reactive.streams.akka;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import akka.stream.stage.GraphStageWithMaterializedValue;
+import scala.Tuple2;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+
+/**
+ * Differs from Flow.watchTermination in that termination callbacks are run in the stream, so if the callback experiences an error,
+ * the stream fails.
+ */
+class TerminationPeeker<T> extends GraphStage<FlowShape<T, T>> {
+  private final Inlet<T> in = Inlet.create("TerminationPeeker.in");
+  private final Outlet<T> out = Outlet.create("TerminationPeeker.out");
+
+  private final FlowShape<T, T> shape = FlowShape.of(in, out);
+
+  private final Runnable onCompleteCallback;
+  private final Consumer<Throwable> onErrorCallback;
+
+  private TerminationPeeker(Runnable onCompleteCallback, Consumer<Throwable> onErrorCallback) {
+    this.onCompleteCallback = onCompleteCallback;
+    this.onErrorCallback = onErrorCallback;
+  }
+
+  static <T> GraphStage<FlowShape<T, T>> onComplete(Runnable action) {
+    return new TerminationPeeker<>(action, t -> {});
+  }
+
+  static <T> GraphStage<FlowShape<T, T>> onTerminate(Runnable action) {
+    return new TerminationPeeker<>(action, t -> action.run());
+  }
+
+  static <T> GraphStage<FlowShape<T, T>> onError(Consumer<Throwable> consumer) {
+    return new TerminationPeeker<>(() -> {}, consumer);
+  }
+
+  @Override
+  public FlowShape<T, T> shape() {
+    return shape;
+  }
+
+  @Override
+  public GraphStageLogic createLogic(Attributes inheritedAttributes) {
+    return new GraphStageLogic(shape()) {
+      {
+        setHandler(in, new AbstractInHandler() {
+          @Override
+          public void onPush() throws Exception {
+            push(out, grab(in));
+          }
+
+          @Override
+          public void onUpstreamFinish() throws Exception {
+            onCompleteCallback.run();
+            complete(out);
+          }
+
+          @Override
+          public void onUpstreamFailure(Throwable ex) throws Exception {
+            onErrorCallback.accept(ex);
+            fail(out, ex);
+          }
+        });
+        setHandler(out, new AbstractOutHandler() {
+          @Override
+          public void onPull() throws Exception {
+            pull(in);
+          }
+
+          @Override
+          public void onDownstreamFinish() throws Exception {
+            onCompleteCallback.run();
+            cancel(in);
+          }
+        });
+      }
+
+    };
+  }
+}

--- a/akka/src/main/java/com/lightbend/microprofile/reactive/streams/akka/TerminationWatcher.java
+++ b/akka/src/main/java/com/lightbend/microprofile/reactive/streams/akka/TerminationWatcher.java
@@ -12,6 +12,9 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+/**
+ * Differs from Flow.watchTermination in that cancellation results in the completion stage failing with a cancellation exception.
+ */
 class TerminationWatcher<T> extends GraphStageWithMaterializedValue<FlowShape<T, T>, CompletionStage<Void>> {
   private final Inlet<T> in = Inlet.create("TerminationWatcher.in");
   private final Outlet<T> out = Outlet.create("TerminationWatcher.out");

--- a/bin/buildDeps.sh
+++ b/bin/buildDeps.sh
@@ -25,6 +25,4 @@ fi
 
 git checkout "${TRACKING_COMMIT}"
 
-cd streams
-
-mvn clean install -Dmaven.test.skip -Drat.skip=true -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dasciidoctor.skip=true
+mvn -am -pl streams/api,streams/tck clean install -Dmaven.test.skip -Drat.skip=true -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dasciidoctor.skip=true

--- a/bin/buildDeps.sh
+++ b/bin/buildDeps.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # This should be set to the commit hash that is being tracked. Needed even if TRACKING_PR is set.
-TRACKING_COMMIT="60f67ef"
+TRACKING_COMMIT="41f41e2"
 # To track a particular pull request, put it's number here, otherwise comment it out.
-TRACKING_PR="64"
+# TRACKING_PR="64"
 
 set -e
 

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/CancelStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/CancelStage.java
@@ -23,9 +23,7 @@ class CancelStage extends GraphStage implements InletListener {
 
   @Override
   protected void postStart() {
-    if (!inlet.isClosed()) {
-      inlet.cancel();
-    }
+    inlet.cancel();
     result.complete(null);
   }
 

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/CollectStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/CollectStage.java
@@ -29,10 +29,7 @@ class CollectStage<T, A, R> extends GraphStage implements InletListener {
 
   @Override
   protected void postStart() {
-    // It's possible that an earlier stage finished immediately, so check first
-    if (!inlet.isClosed()) {
-      inlet.pull();
-    }
+    inlet.pull();
   }
 
   @Override
@@ -43,7 +40,11 @@ class CollectStage<T, A, R> extends GraphStage implements InletListener {
 
   @Override
   public void onUpstreamFinish() {
-    result.complete(collector.finisher().apply(container));
+    try {
+      result.complete(collector.finisher().apply(container));
+    } catch (RuntimeException e) {
+      result.completeExceptionally(e);
+    }
     container = null;
   }
 

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/ConnectorStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/ConnectorStage.java
@@ -7,6 +7,8 @@ package com.lightbend.microprofile.reactive.streams.zerodep;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
+import java.util.Objects;
+
 /**
  * Connector stage. Does nothing but connects a publisher to a subscriber when the graph starts.
  */
@@ -16,8 +18,8 @@ public class ConnectorStage<T> extends GraphStage {
 
   public ConnectorStage(BuiltGraph builtGraph, Publisher<T> publisher, Subscriber<T> subscriber) {
     super(builtGraph);
-    this.publisher = publisher;
-    this.subscriber = subscriber;
+    this.publisher = Objects.requireNonNull(publisher);
+    this.subscriber = Objects.requireNonNull(subscriber);
   }
 
   @Override

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/FailedStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/FailedStage.java
@@ -21,9 +21,7 @@ class FailedStage extends GraphStage implements OutletListener {
 
   @Override
   protected void postStart() {
-    if (!outlet.isClosed()) {
-      outlet.fail(error);
-    }
+    outlet.fail(error);
   }
 
   @Override

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/FindFirstStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/FindFirstStage.java
@@ -22,9 +22,7 @@ class FindFirstStage<T> extends GraphStage implements InletListener {
 
   @Override
   protected void postStart() {
-    if (!inlet.isClosed()) {
-      inlet.pull();
-    }
+    inlet.pull();
   }
 
   @Override

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/GraphStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/GraphStage.java
@@ -37,13 +37,6 @@ abstract class GraphStage {
 
   /**
    * Run a callback after the graph has started.
-   * <p>
-   * When implementing this, it's important to remember that this is executed *after* the graph has started. It's
-   * possible that the stage will receive other signals before this is executed, which may have been triggered from
-   * the postStart methods on other stages. So this should not be used to do initialisation that should be done
-   * before the stage is ready to receive signals, that initialisation should be done in the constructor, rather,
-   * this can be used to initiate signals, but care needs to be taken, for example, a stage that just completes
-   * immediately should check whether the outlet is completed first, since it may have been by a previous callback.
    */
   protected void postStart() {
     // Do nothing by default

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/LimitStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/LimitStage.java
@@ -33,18 +33,15 @@ class LimitStage<T> extends GraphStage implements InletListener {
   @Override
   public void onPush() {
     T element = inlet.grab();
-    count++;
-    if (count <= maxSize) {
-      outlet.push(element);
-      if (count == maxSize) {
-        closeAll();
-      }
+    outlet.push(element);
+    if (++count == maxSize) {
+      closeAll();
     }
   }
 
   private void closeAll() {
-    if (!outlet.isClosed()) outlet.complete();
-    if (!inlet.isClosed()) inlet.cancel();
+    outlet.complete();
+    inlet.cancel();
   }
 
   @Override

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/OfStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/OfStage.java
@@ -23,17 +23,15 @@ class OfStage<T> extends GraphStage implements OutletListener {
 
   @Override
   protected void postStart() {
-    if (!outlet.isClosed()) {
-      if (!elements.hasNext()) {
-        outlet.complete();
-      }
+    if (!elements.hasNext()) {
+      outlet.complete();
     }
   }
 
   @Override
   public void onPull() {
     outlet.push(elements.next());
-    if (!elements.hasNext() && !outlet.isClosed()) {
+    if (!elements.hasNext()) {
       outlet.complete();
     }
   }

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/OnCompleteStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/OnCompleteStage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.microprofile.reactive.streams.zerodep;
+
+class OnCompleteStage<T> extends GraphStage implements InletListener {
+  private final StageInlet<T> inlet;
+  private final StageOutlet<T> outlet;
+  private final Runnable action;
+
+  OnCompleteStage(BuiltGraph builtGraph, StageInlet<T> inlet, StageOutlet<T> outlet, Runnable action) {
+    super(builtGraph);
+    this.inlet = inlet;
+    this.outlet = outlet;
+    this.action = action;
+
+    inlet.setListener(this);
+    outlet.forwardTo(inlet);
+  }
+
+  @Override
+  public void onPush() {
+    outlet.push(inlet.grab());
+  }
+
+  @Override
+  public void onUpstreamFinish() {
+    try {
+      action.run();
+      outlet.complete();
+    } catch (RuntimeException e) {
+      outlet.fail(e);
+    }
+  }
+
+  @Override
+  public void onUpstreamFailure(Throwable error) {
+    outlet.fail(error);
+  }
+}

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/OnErrorStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/OnErrorStage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.microprofile.reactive.streams.zerodep;
+
+import java.util.function.Consumer;
+
+class OnErrorStage<T> extends GraphStage implements InletListener {
+  private final StageInlet<T> inlet;
+  private final StageOutlet<T> outlet;
+  private final Consumer<Throwable> consumer;
+
+  OnErrorStage(BuiltGraph builtGraph, StageInlet<T> inlet, StageOutlet<T> outlet, Consumer<Throwable> consumer) {
+    super(builtGraph);
+    this.inlet = inlet;
+    this.outlet = outlet;
+    this.consumer = consumer;
+
+    inlet.setListener(this);
+    outlet.forwardTo(inlet);
+  }
+
+  @Override
+  public void onPush() {
+    outlet.push(inlet.grab());
+  }
+
+  @Override
+  public void onUpstreamFinish() {
+    outlet.complete();
+  }
+
+  @Override
+  public void onUpstreamFailure(Throwable error) {
+    try {
+      outlet.fail(error);
+    } catch (RuntimeException e) {
+      error = e;
+    }
+    consumer.accept(error);
+  }
+}

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/OnTerminateStage.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/OnTerminateStage.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.microprofile.reactive.streams.zerodep;
+
+public class OnTerminateStage<T> extends GraphStage implements InletListener, OutletListener {
+  private final StageInlet<T> inlet;
+  private final StageOutlet<T> outlet;
+  private final Runnable action;
+
+  public OnTerminateStage(BuiltGraph builtGraph, StageInlet<T> inlet, StageOutlet<T> outlet, Runnable action) {
+    super(builtGraph);
+    this.inlet = inlet;
+    this.outlet = outlet;
+    this.action = action;
+
+    inlet.setListener(this);
+    outlet.setListener(this);
+  }
+
+  @Override
+  public void onPush() {
+    outlet.push(inlet.grab());
+  }
+
+  @Override
+  public void onUpstreamFinish() {
+    try {
+      action.run();
+      outlet.complete();
+    } catch (RuntimeException e) {
+      outlet.fail(e);
+    }
+  }
+
+  @Override
+  public void onUpstreamFailure(Throwable error) {
+    try {
+      action.run();
+    } catch (Exception e) {
+      error = e;
+    }
+    outlet.fail(error);
+  }
+
+  @Override
+  public void onPull() {
+    inlet.pull();
+  }
+
+  @Override
+  public void onDownstreamFinish() {
+    try {
+      action.run();
+    } catch (Exception e) {
+      // Ignore??
+    } finally {
+      inlet.cancel();
+    }
+  }
+}

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/Port.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/Port.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.microprofile.reactive.streams.zerodep;
+
+/**
+ * A port, which may sit between two stages of this graph.
+ */
+interface Port {
+  /**
+   * If an exception is thrown by the graph, or otherwise encountered, each port will be shut down in the order they
+   * were created, by invoking this. This method should implement any clean up associated with a port, if the port
+   * isn't already shut down.
+   */
+  void onStreamFailure(Throwable reason);
+
+  /**
+   * Verify that this port is ready to start receiving signals.
+   */
+  void verifyReady();
+}

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/Signal.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/Signal.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.microprofile.reactive.streams.zerodep;
+
+/**
+ * A signal, used by inlets and outlets.
+ *
+ * A signal represents a callback to an inlet or outlet listener. All callbacks should be wrapped in a signal to
+ * allow signals to be enqueued, so that they can be executed in an unrolled fashion, rather than recursively.
+ *
+ * Implementations of signal are only allocated when a stream or sub stream starts. They should carry no state, any
+ * state associated with the signal should be held by the inlet or outlet. This ensures that no allocations are done
+ * of signals while running the stream.
+ */
+public interface Signal {
+  /**
+   * Invoke the signal.
+   */
+  void signal();
+
+  /**
+   * This will be invoked if {@link #signal()} throws an exception. Implementations of this should then terminate both
+   * upstream and downstream. This mechanism means that {@code signal} doesn't have to do its own exception handling,
+   * but rather exceptions can be handled generically by a stage.
+   */
+  void signalFailed(Throwable t);
+}

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/StageInlet.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/StageInlet.java
@@ -95,12 +95,18 @@ interface InletListener {
 
   /**
    * Indicates that upstream has completed the stream. No signals may be sent to the inlet after this has been invoked.
+   *
+   * This must be very careful not to throw an exception. If it does, then the signal to complete will not reach
+   * downstream.
    */
   void onUpstreamFinish();
 
   /**
    * Indicates that upstream has completed the stream with a failure. No signals may be sent to the inlet after this has
    * been invoked.
+   *
+   * This must be very careful not to throw an exception. If it does, then the signal to complete will not reach
+   * downstream.
    */
   void onUpstreamFailure(Throwable error);
 }

--- a/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/StageOutlet.java
+++ b/zerodep/src/main/java/com/lightbend/microprofile/reactive/streams/zerodep/StageOutlet.java
@@ -84,6 +84,9 @@ interface OutletListener {
   /**
    * A completion signal, indicates that downstream has completed. No further signals may be sent to this outlet after
    * this signal is received.
+   *
+   * This must be very careful not to throw an exception. If it does, then the signal to cancel will not reach
+   * upstream.
    */
   void onDownstreamFinish();
 }

--- a/zerodep/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/ReactiveStreamsEngineImplTckTest.java
+++ b/zerodep/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/ReactiveStreamsEngineImplTckTest.java
@@ -4,7 +4,7 @@
 
 package com.lightbend.microprofile.reactive.streams.zerodep;
 
-import org.eclipse.microprofile.reactive.streams.tck.ReactiveStreamsTck;
+import org.eclipse.microprofile.reactive.streams.tck.*;
 import org.reactivestreams.tck.TestEnvironment;
 
 public class ReactiveStreamsEngineImplTckTest extends ReactiveStreamsTck<ReactiveStreamsEngineImpl> {
@@ -17,5 +17,4 @@ public class ReactiveStreamsEngineImplTckTest extends ReactiveStreamsTck<Reactiv
   protected ReactiveStreamsEngineImpl createEngine() {
     return new ReactiveStreamsEngineImpl();
   }
-
 }


### PR DESCRIPTION
* All signals between stages are now unrolled before dispatch, ensuring
  stages don't need to worry about recursive invocations.
* This also made the implementation of the inlets/outlets much simpler,
  as they also didn't have to worry about recursive invocations.
* Failure of a single stage is now handled by cancelling upstream, and
  signalling onUpstreamError in that stage. This will be needed when it
  comes to implementing the stream recovery features.
* Also implemented the Akka onError etc stages.