### PR TITLE
Zerodep in container TCK

### DIFF
--- a/bin/buildDeps.sh
+++ b/bin/buildDeps.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # This should be set to the commit hash that is being tracked. Needed even if TRACKING_PR is set.
-TRACKING_COMMIT="0d0c4f50"
+TRACKING_COMMIT="4a1ee95"
 # To track a particular pull request, put it's number here, otherwise comment it out.
-# TRACKING_PR="67"
+TRACKING_PR="84"
 
 set -e
 
@@ -25,4 +25,4 @@ fi
 
 git checkout "${TRACKING_COMMIT}"
 
-mvn -am -pl streams/api,streams/tck clean install -Dmaven.test.skip -Drat.skip=true -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dasciidoctor.skip=true
+mvn -am -pl streams/api,streams/tck,streams/tck-arquillian clean install -Dmaven.test.skip -Drat.skip=true -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dasciidoctor.skip=true

--- a/bin/buildDeps.sh
+++ b/bin/buildDeps.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # This should be set to the commit hash that is being tracked. Needed even if TRACKING_PR is set.
-TRACKING_COMMIT="4a1ee95"
+TRACKING_COMMIT="6387275"
 # To track a particular pull request, put it's number here, otherwise comment it out.
-TRACKING_PR="84"
+# TRACKING_PR="84"
 
 set -e
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <modules>
         <module>akka</module>
         <module>zerodep</module>
+        <module>zerodep-cdi</module>
     </modules>
 
     <dependencyManagement>
@@ -74,6 +75,11 @@
             <dependency>
                 <groupId>org.eclipse.microprofile.reactive.streams</groupId>
                 <artifactId>microprofile-reactive-streams-operators-tck</artifactId>
+                <version>${microprofile.reactive.streams.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+                <artifactId>microprofile-reactive-streams-operators-tck-arquillian</artifactId>
                 <version>${microprofile.reactive.streams.version}</version>
             </dependency>
             <dependency>

--- a/zerodep-cdi/pom.xml
+++ b/zerodep-cdi/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.lightbend.microprofile.reactive.streams</groupId>
+        <artifactId>lightbend-microprofile-reactive-streams-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>lightbend-microprofile-reactive-streams-zerodep-cdi</artifactId>
+    <name>Lightbend MicroProfile Reactive Streams Operators Zero Dependency CDI</name>
+    <description>Lightbend MicroProfile Reactive Streams Operators :: Zero Dependency CDI Integration</description>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>lightbend-microprofile-reactive-streams-zerodep</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.reactive.streams</groupId>
+            <artifactId>microprofile-reactive-streams-operators-tck-arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.arquillian.junit</groupId>
+                    <artifactId>arquillian-junit-container</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>javax.enterprise</groupId>
+                <artifactId>cdi-api</artifactId>
+                <version>2.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.1.15.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.thorntail</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.0.0.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/zerodep-cdi/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/cdi/ReactiveStreamsArquillianTckTest.java
+++ b/zerodep-cdi/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/cdi/ReactiveStreamsArquillianTckTest.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.microprofile.reactive.streams.zerodep.cdi;
+
+import org.eclipse.microprofile.reactive.streams.tck.arquillian.ReactiveStreamsArquillianTck;
+
+/**
+ * This class exists purely to bring in the TCK so that it gets automatically picked up by surefire, and can be run by
+ * IntelliJ.
+ */
+public class ReactiveStreamsArquillianTckTest extends ReactiveStreamsArquillianTck {
+}

--- a/zerodep-cdi/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/cdi/ZeroDepArchiveAppender.java
+++ b/zerodep-cdi/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/cdi/ZeroDepArchiveAppender.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.microprofile.reactive.streams.zerodep.cdi;
+
+import com.lightbend.microprofile.reactive.streams.zerodep.ReactiveStreamsEngineImpl;
+import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.reactivestreams.Publisher;
+
+/**
+ * Adds the Reactive Streams operators API as well as the zerodep implementation to Thorntail.
+ */
+public class ZeroDepArchiveAppender implements AuxiliaryArchiveAppender {
+  @Override
+  public Archive<?> createAuxiliaryArchive() {
+    return ShrinkWrap.create(JavaArchive.class)
+        .addPackages(true, ReactiveStreams.class.getPackage())
+        .addPackages(true, Publisher.class.getPackage())
+        // For some reason, Thorntail automatically creates a bean for this, and I don't know why.
+        // When I tried to add another application scoped bean that @Produces this, it failed with
+        // an ambiguous dependency because both that, and the one that Thorntail automatically
+        // created, existed. I have no idea how that's happening.
+        .addPackages(true, ReactiveStreamsEngineImpl.class.getPackage());
+  }
+}

--- a/zerodep-cdi/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/cdi/ZeroDepArchiveAppender.java
+++ b/zerodep-cdi/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/cdi/ZeroDepArchiveAppender.java
@@ -3,6 +3,7 @@
  */
 package com.lightbend.microprofile.reactive.streams.zerodep.cdi;
 
+import com.beust.jcommander.JCommander;
 import com.lightbend.microprofile.reactive.streams.zerodep.ReactiveStreamsEngineImpl;
 import org.eclipse.microprofile.reactive.streams.ReactiveStreams;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
@@ -24,6 +25,8 @@ public class ZeroDepArchiveAppender implements AuxiliaryArchiveAppender {
         // When I tried to add another application scoped bean that @Produces this, it failed with
         // an ambiguous dependency because both that, and the one that Thorntail automatically
         // created, existed. I have no idea how that's happening.
-        .addPackages(true, ReactiveStreamsEngineImpl.class.getPackage());
+        .addPackages(true, ReactiveStreamsEngineImpl.class.getPackage())
+        // Because TestNG depends on it but this old verison of Arquillian doesn't bring it in.
+        .addPackages(true, JCommander.class.getPackage());
   }
 }

--- a/zerodep-cdi/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/cdi/ZeroDepExtension.java
+++ b/zerodep-cdi/src/test/java/com/lightbend/microprofile/reactive/streams/zerodep/cdi/ZeroDepExtension.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.microprofile.reactive.streams.zerodep.cdi;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * Arquillian extension to register the archive appender.
+ */
+public class ZeroDepExtension implements LoadableExtension {
+  @Override
+  public void register(ExtensionBuilder extensionBuilder) {
+    extensionBuilder.service(AuxiliaryArchiveAppender.class, ZeroDepArchiveAppender.class);
+  }
+}

--- a/zerodep-cdi/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/zerodep-cdi/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+#
+com.lightbend.microprofile.reactive.streams.zerodep.cdi.ZeroDepExtension


### PR DESCRIPTION
Added tests for the zerodep implementation to use the Arquillian Reactive Streams TCK test to run the tests in a container (Thorntail, but should be straight forward to switch to anything else).